### PR TITLE
Gleichheitsgrundsatz entfernt.

### DIFF
--- a/masterthesis.tex
+++ b/masterthesis.tex
@@ -423,9 +423,6 @@ Pers. Kennz. \campusPersKnz
 % Kurzfassung / Abstract
 \input{misc/Kurzfassung}
 
-% Gleichheitsgrundsatz
-\input{misc/Gleichheitsgrundsatz}
-
 % Inhaltsverzeichnis
 \tableofcontents
 

--- a/misc/Gleichheitsgrundsatz.tex
+++ b/misc/Gleichheitsgrundsatz.tex
@@ -1,5 +1,0 @@
-% vim: set tw=160:
-
-\chapter*{Gleichheitsgrundsatz}
-Aus Gründen der Lesbarkeit wurde in dieser Arbeit darauf verzichtet, geschlechtsspezifische Formulierungen zu verwenden. Jedoch möchte der Author ausdrücklich
-festhalten, dass die bei Personen verwendeten femininen oder maskulinen Formen für beide Geschlechter zu verstehen sind.


### PR DESCRIPTION
Gleichheitsgrundsatz entfernt. Ab SS15 ist in IWI-Arbeiten gendern notwendig.
